### PR TITLE
Fixed float format character assert

### DIFF
--- a/src/infi/instruct/buffer/serialize.py
+++ b/src/infi/instruct/buffer/serialize.py
@@ -126,7 +126,7 @@ def unpack_int(buffer, **kwargs):
 
 def format_from_struct_float_arguments(format_char, kwargs):
     args = copy_defaults_and_override_with_kwargs(dict(endian='native'), kwargs)
-    assert_enum_argument('format_char', format_char, ('f', 'd'))
+    assert_enum_argument('format_char', format_char, ('f', 'q'))
     assert_kwarg_enum(args, 'endian', ENDIAN_NAME_TO_FORMAT.keys())
     return "{0}{1}".format(ENDIAN_NAME_TO_FORMAT[args["endian"]], format_char)
 

--- a/src/infi/instruct/buffer/serialize.py
+++ b/src/infi/instruct/buffer/serialize.py
@@ -126,7 +126,7 @@ def unpack_int(buffer, **kwargs):
 
 def format_from_struct_float_arguments(format_char, kwargs):
     args = copy_defaults_and_override_with_kwargs(dict(endian='native'), kwargs)
-    assert_enum_argument('format_char', format_char, ('f', 'q'))
+    assert_enum_argument('format_char', format_char, ('f', 'd'))
     assert_kwarg_enum(args, 'endian', ENDIAN_NAME_TO_FORMAT.keys())
     return "{0}{1}".format(ENDIAN_NAME_TO_FORMAT[args["endian"]], format_char)
 
@@ -145,7 +145,7 @@ def pack_float(value, **kwargs):
 
 STRUCT_FLOAT_PACKERS = {
     4: keep_kwargs_partial(pack_struct_float, format_char='f'),
-    8: keep_kwargs_partial(pack_struct_float, format_char='q')
+    8: keep_kwargs_partial(pack_struct_float, format_char='d')
 }
 
 


### PR DESCRIPTION
STRUCT_FLOAT_PACKERS has format characters 'f' and 'q', but format_from_struct_float_arguments checked against 'f' and 'd'. This prevented 8 byte floats from being used.